### PR TITLE
Update publishing to Kali DAO npm repo

### DIFF
--- a/.changeset/rich-balloons-smell.md
+++ b/.changeset/rich-balloons-smell.md
@@ -1,0 +1,5 @@
+---
+'kalidao-hooks': patch
+---
+
+Transition to Kali DAO npm repo

--- a/.changeset/young-kiwis-work.md
+++ b/.changeset/young-kiwis-work.md
@@ -1,0 +1,5 @@
+---
+'@kalidao/hooks': patch
+---
+
+update npm refs to @kalidao/hooks

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -175,6 +175,8 @@ If your PR is making changes to an area that already has a changeset (e.g. there
 
 ### Releasing
 
+Use `pnpm changeset` to prepare a new release.
+
 The first time a PR with a changeset is merged after a release, a new PR will automatically be created called `chore: version packages`. Any subsequent PRs with changesets will automatically update this existing version packages PR. Merging this PR triggers the release process by publishing to npm and cleaning up the changeset files.
 
 ### Creating a snapshot release

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Checks if the user is connected to a target chain. Useful for preventing users f
 Example React component snippet:
 
 ```TypeScript
-import { useChainGuard } from 'kalidao-hooks'
+import { useChainGuard } from '@kalidao/hooks'
 
 const daoHomeChain = chain.arbitrum
 const { isUserOnCorrectChain, isUserConnected, userChain } = useChainGuard({ chainId: daoHomeChain.id })

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kalidao-hooks",
+  "name": "@kalidao/hooks",
   "description": "React Hooks for Ethereum",
   "license": "MIT",
   "version": "0.0.3",


### PR DESCRIPTION
## Description

Currently npm releases go to ivelin's personal npm repo. @nerderlyne provided token access for publishing to kali's official repo. This PR aims to implement the switch.

## Additional Information

- [x] I read the [contributing docs](/kalidao/hooks/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: ivelin.eth

